### PR TITLE
Use SHA for pulling docker reference instead of `latest`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ghcr.io/infratographer/porton/porton@sha256:2f3beaad98c6083ce950ffd69a32ce065fb57f32f6f1cbd13de26fc636f776b9
 
+USER root
+
 # Install the configuration file in the expected path
 COPY krakend.tmpl /etc/krakend-src/config/krakend.tmpl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# TODO: Add renovate configuration that will track GitHub releases
-# The intent is to use release tags instead of commit hashes
-FROM ghcr.io/infratographer/porton/porton:latest
+FROM ghcr.io/infratographer/porton/porton@sha256:2f3beaad98c6083ce950ffd69a32ce065fb57f32f6f1cbd13de26fc636f776b9
 
 # Install the configuration file in the expected path
 COPY krakend.tmpl /etc/krakend-src/config/krakend.tmpl


### PR DESCRIPTION
This ensures that we can still use the "latest" image, but have a clear
reference of the container we're actually building from. This helps us
not have to rely on a full release workflow for the base image since it
just pulls from krakend and won't be updated as much.

Also, switch to using root to ensure the container setup succeeds. A non-root user
is used at a later stage.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
