### PR TITLE
Add loadbalancer-api endpoints

### DIFF
--- a/endpoints/loadbalancer.api/endpoints.yaml
+++ b/endpoints/loadbalancer.api/endpoints.yaml
@@ -1,0 +1,131 @@
+#### loadbalancers
+- $schema: https://www.krakend.io/schema/endpoint.json
+  $id: "#endpoint/endpoint"
+  endpoint: /v1/tenant/{tenantID}/load_balancers
+  method: GET
+  input_headers: &input_headers
+    - Authorization
+    - Host
+    - Content-Type
+    - Content-Length
+  output_encoding: &outputEncoding no-op
+  backend:
+    - url_pattern: /v1/tenant/{tenantID}/loadbalancers
+      method: GET
+      host: &hosts
+        - http://host.docker.internal:7608
+      extra_config: &extraConfig {}
+- $schema: https://www.krakend.io/schema/endpoint.json
+  $id: "#endpoint/endpoint"
+  endpoint: /v1/load_balancers/{loadBalancerID}
+  method: GET
+  input_headers: *input_headers
+  output_encoding: *outputEncoding
+  backend:
+    - url_pattern: /v1/loadbalancers/{loadBalancerID}
+      method: GET
+      host: *hosts
+      extra_config: *extraConfig
+- $schema: https://www.krakend.io/schema/endpoint.json
+  $id: "#endpoint/endpoint"
+  endpoint: /v1/tenant/{tenantID}/load_balancers
+  method: POST
+  input_headers: *input_headers
+  output_encoding: *outputEncoding
+  backend:
+    - url_pattern: /v1/tenant/{tenantID}/loadbalancers
+      method: POST
+      host: *hosts
+      extra_config: *extraConfig
+
+#### ports
+- $schema: https://www.krakend.io/schema/endpoint.json
+  $id: "#endpoint/endpoint"
+  endpoint: /v1/load_balancers/{loadBalancerID}/ports
+  method: POST
+  input_headers: *input_headers
+  output_encoding: *outputEncoding
+  backend:
+    - url_pattern: /v1/loadbalancers/{loadBalancerID}/ports
+      method: POST
+      host: *hosts
+      extra_config: *extraConfig
+- $schema: https://www.krakend.io/schema/endpoint.json
+  $id: "#endpoint/endpoint"
+  endpoint: /v1/load_balancers/{loadBalancerID}/ports/{portID}
+  method: PUT
+  input_headers: *input_headers
+  output_encoding: *outputEncoding
+  backend:
+    - url_pattern: /v1/ports/{portID}
+      method: PUT
+      host: *hosts
+      extra_config: *extraConfig
+- $schema: https://www.krakend.io/schema/endpoint.json
+  $id: "#endpoint/endpoint"
+  endpoint: /v1/load_balancers/{loadBalancerID}/ports/{portID}
+  method: PATCH
+  input_headers: *input_headers
+  output_encoding: *outputEncoding
+  backend:
+    - url_pattern: /v1/ports/{portID}
+      method: PATCH
+      host: *hosts
+      extra_config: *extraConfig
+- $schema: https://www.krakend.io/schema/endpoint.json
+  $id: "#endpoint/endpoint"
+  endpoint: /v1/load_balancers/{loadBalancerID}/ports/{portID}
+  method: DELETE
+  input_headers: *input_headers
+  output_encoding: *outputEncoding
+  backend:
+    - url_pattern: /v1/ports/{portID}
+      method: DELETE
+      host: *hosts
+      extra_config: *extraConfig
+
+#### pools
+- $schema: https://www.krakend.io/schema/endpoint.json
+  $id: "#endpoint/endpoint"
+  endpoint: /v1/tenant/{tenantID}/load_balancers/pools
+  method: POST
+  input_headers: *input_headers
+  output_encoding: *outputEncoding
+  backend:
+    - url_pattern: /v1/tenant/{tenantID}/pools
+      method: POST
+      host: *hosts
+      extra_config: *extraConfig
+- $schema: https://www.krakend.io/schema/endpoint.json
+  $id: "#endpoint/endpoint"
+  endpoint: /v1/load_balancers/pools/{poolID}
+  method: GET
+  input_headers: *input_headers
+  output_encoding: *outputEncoding
+  backend:
+    - url_pattern: /v1/pools/{poolID}
+      method: GET
+      host: *hosts
+      extra_config: *extraConfig
+- $schema: https://www.krakend.io/schema/endpoint.json
+  $id: "#endpoint/endpoint"
+  endpoint: /v1/load_balancers/pools/{poolID}
+  method: PATCH
+  input_headers: *input_headers
+  output_encoding: *outputEncoding
+  backend:
+    - url_pattern: /v1/pools/{poolID}
+      method: PATCH
+      host: *hosts
+      extra_config: *extraConfig
+- $schema: https://www.krakend.io/schema/endpoint.json
+  $id: "#endpoint/endpoint"
+  endpoint: /v1/load_balancers/pools/{poolID}
+  method: PUT
+  input_headers: *input_headers
+  output_encoding: *outputEncoding
+  backend:
+    - url_pattern: /v1/pools/{poolID}
+      method: PUT
+      host: *hosts
+      extra_config: *extraConfig


### PR DESCRIPTION
```
# Ensure local dev container for loadbalancer-api is up and running and exposed on port 7608
curl  localhost:7608/v1/tenant/8263b19b-6aea-4dd7-a2cd-ffa7efe513e9/loadbalancers
{
  "version": "v1",
  "kind": "loadBalancersList",
  "load_balancers": []
}

# spin up local api-gateway
make run-local

# hit api gateway
curl -k https://localhost:8080/loadbalancer.api/v1/tenant/8263b19b-6aea-4dd7-a2cd-ffa7efe513e9/load_balancers
{
  "version": "v1",
  "kind": "loadBalancersList",
  "load_balancers": []
}
```